### PR TITLE
Added item_number to line item query parameters

### DIFF
--- a/activerecord/models/ipn_order_model.php
+++ b/activerecord/models/ipn_order_model.php
@@ -66,8 +66,11 @@ class Ipn_order_model extends CI_Model
         foreach ($orderItems as $item)
         {
             // Define the order item query
-            $orderItemQuery = array('item_name' => $item['item_name'],
-                                    'order_id'  => $orderID);
+            $orderItemQuery = array(
+                'item_name' => $item['item_name'],
+                'item_number' => $item['item_number'],
+                'order_id'  => $orderID
+            );
 
             // Add the order ID and datestamp into the item to update/insert
             $item['order_id'] = $orderID;


### PR DESCRIPTION
PayPal IPN groups items by item_number, so it is possible to have
multiple line items with the same name within a single order.
